### PR TITLE
Fix for existing stylesheets that may not have cssRules defined.

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -47,6 +47,9 @@
   var animations = {};
   var useCssAnimations;
 
+  /* Variable to access dynamically created stylesheet for storing animations */
+  var sheet;
+
   /**
    * 
    */
@@ -75,11 +78,12 @@
   }
 
   function styleSheet() {
-    var sheets = document.styleSheets;
-    if (!sheets[length]) {
-      ins(document.documentElement[firstChild], createEl(style));
+    if (!sheet) {
+     ins(document.documentElement[firstChild], createEl(style));
+     sheet = document.styleSheets[document.styleSheets.length - 1];
     }
-    return sheets[0];
+
+    return sheet;
   }
 
   /**


### PR DESCRIPTION
Currently, spin.js finds the first stylesheet on the page, and then appends rules onto it. Unfortunately, a lot of stylesheets appear to have no cssRules variable. Instead, I've updated it to always create its own stylesheet, and append rules onto it.
