### PR TITLE
Fixing Invalid Argument JS error in Internet Explorer

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -41,7 +41,7 @@
     var el = createEl('style');
     ins(document.getElementsByTagName('head')[0], el);
     return el.sheet || el.styleSheet;
-  }();
+  };
 
   /**
    * Creates an opacity keyframe animation rule and returns its name.


### PR DESCRIPTION
This set of empty parentheses following the closing curly brace of a function definition was causing an error in Internet Explorer.  When they're removed IE works fine.  Firefox and Chrome are unaffected.  Was there a reason for them being there, or is their inclusion strictly an error?
