### PR TITLE
Fixing Invalid Argument JS error in Internet Explorer

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -38,7 +38,7 @@
    * Insert a new stylesheet to hold the @keyframe or VML rules.
    */
   var sheet = function() {
-    var el = createEl('style');
+    var el = createEl('style', {type : 'text/css'});
     ins(document.getElementsByTagName('head')[0], el);
     return el.sheet || el.styleSheet;
   }();


### PR DESCRIPTION
caused by using createElement without passing it a type attribute.

Signed-off-by: Ben McIlwain bmcilwain@ngpvan.com
