### PR TITLE
added leading semicolon to prevent file concat issues

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -1,5 +1,5 @@
 //fgnass.github.com/spin.js#v1.2.5
-(function(window, document, undefined) {
+;(function(window, document, undefined) {
 
 /**
  * Copyright (c) 2011 Felix Gnass [fgnass at neteye dot de]


### PR DESCRIPTION
I understand this to be a best practice. If this file is concatenated into a larger file and the previous file does not end with a semicolon these parens could be interpreted incorrectly.
