### PR TITLE
Added stylistic control to shadows

### DIFF
--- a/example/shadow.html
+++ b/example/shadow.html
@@ -43,21 +43,21 @@
 <script>
   var opts = [
     {
-      color: '#008',
-      shadow: '0px 0px 2px #fff'
+      color: '#222',
+      shadow: '0px 0px 2px #f00'
     },
     {
-      color: '#080',
+      color: '#222',
       shadow: {
         left: '2px',
         top: '2px',
         radius: '2px',
-        color: '#fff'
+        color: '#0f0'
       }
     },
     {
-      color: '#800',
-      shadow: '-2px -2px 2px #999'
+      color: '#222',
+      shadow: '-2px -2px 2px #00f'
     }
   ];
   

--- a/example/shadow.html
+++ b/example/shadow.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html>
+<head>
+  <title>spin.js</title>
+  <style type="text/css">
+  body {
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    padding: 0;
+    margin: 0;
+  }
+  div {
+    border-radius: 10px;
+  }
+  #target1 {
+    background: #aaa url(../assets/crosshair.gif) center center no-repeat;
+    width: 99px;
+    height: 99px;
+    padding: 15px;
+  }
+  #target2 {
+    background: #bbb url(../assets/crosshair.gif) center center no-repeat;
+    width: 99px;
+    height: 99px;
+    padding: 15px;
+  }
+  #target3 {
+    background: #ccc url(../assets/crosshair.gif) center center no-repeat;
+    width: 99px;
+    height: 99px;
+    padding: 15px;
+  }
+  </style>
+</head>
+<body>
+
+<div id="target1"></div>
+<div id="target2"></div>
+<div id="target3"></div>
+
+<script src="../spin.js"></script>
+
+<script>
+  var opts = [
+    {
+      color: '#008',
+      shadow: '0px 0px 2px #fff'
+    },
+    {
+      color: '#080',
+      shadow: {
+        left: '2px',
+        top: '2px',
+        radius: '2px',
+        color: '#fff'
+      }
+    },
+    {
+      color: '#800',
+      shadow: '-2px -2px 2px #999'
+    }
+  ];
+  
+  for (var i = 0, c = opts.length; i < c; i++) {
+    Spinner(opts[i]).spin(document.getElementById('target' + (i + 1)));
+  }
+</script>
+
+</body>
+</html>

--- a/spin.js
+++ b/spin.js
@@ -229,7 +229,9 @@
       
       // Determine how to draw the shadow
       var shadow = parseShadow(o.shadow);
-      shadow.string = '0 0 ' + shadow.radius + ' ' + shadow.color;
+      if (shadow) {
+        shadow.string = '0 0 ' + shadow.radius + ' ' + shadow.color;
+	    }
 
       function fill(color, shadow) {
         return css(createEl(), {

--- a/spin.js
+++ b/spin.js
@@ -223,7 +223,6 @@
         });
         // Build the final shadow string
         shadow.string = [shadow.left, shadow.top, shadow.radius, shadow.color].join(' ');
-        console.log(shadow.string);
       }
 
       function fill(color, shadow) {

--- a/spin.js
+++ b/spin.js
@@ -317,7 +317,7 @@
           var shadow = parseShadow(o.shadow);
           var filter = [
             'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + shadow.radius + ')',
-            'progid:DXImageTransform.Microsoft.Alpha(Opacity=' + (100 - parseInt(shadow.radius) * 10) + ')'
+            'progid:DXImageTransform.Microsoft.Alpha(Opacity=50)'
           ].join(' ');
           for (i = 1; i <= o.lines; i++) {
             seg(i, 0, filter, shadow.color);

--- a/spin.js
+++ b/spin.js
@@ -198,6 +198,33 @@
     lines: function(el, o) {
       var i = 0;
       var seg;
+      
+      // Determine how to draw the shadow
+      var shadow = o.shadow;
+      if (shadow) {
+        // Allow a shadow property string (eg. "0 0 4px #000")
+        if (typeof shadow === 'string') {
+          var segments = shadow.split(' ');
+          shadow = { };
+          shadow.left    = segments.shift();
+          shadow.top     = segments.shift();
+          shadow.radius  = segments.shift();
+          shadow.color   = segments.join(' ');
+        }
+        // If the shadow was not given as a string or object, assume it
+        // was boolean true (for backward compat) and default to an empty object
+        shadow = (typeof shadow === 'object') ? shadow : { };
+        // Default any ungiven shadow values
+        shadow = merge(shadow, {
+          top: '0',
+          left: '0',
+          radius: '4px',
+          color: '#000'
+        });
+        // Build the final shadow string
+        shadow.string = [shadow.left, shadow.top, shadow.radius, shadow.color].join(' ');
+        console.log(shadow.string);
+      }
 
       function fill(color, shadow) {
         return css(createEl(), {
@@ -219,7 +246,7 @@
           opacity: o.opacity,
           animation: useCssAnimations && addAnimation(o.opacity, o.trail, i, o.lines) + ' ' + 1/o.speed + 's linear infinite'
         });
-        if (o.shadow) ins(seg, css(fill('#000', '0 0 4px ' + '#000'), {top: 2+'px'}));
+        if (o.shadow) ins(seg, css(fill(shadow.color, shadow.string), {top: 2+'px'}));
         ins(el, ins(seg, fill(o.color, '0 0 1px rgba(0,0,0,.1)')));
       }
       return el;

--- a/spin.js
+++ b/spin.js
@@ -231,7 +231,7 @@
       var shadow = parseShadow(o.shadow);
       if (shadow) {
         shadow.string = '0 0 ' + shadow.radius + ' ' + shadow.color;
-	    }
+      }
 
       function fill(color, shadow) {
         return css(createEl(), {
@@ -315,7 +315,10 @@
 
         if (o.shadow) {
           var shadow = parseShadow(o.shadow);
-          var filter = 'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + shadow.radius + ',shadowopacity=.3)';
+          var filter = [
+            'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + shadow.radius + ')',
+            'progid:DXImageTransform.Microsoft.Alpha(Opacity=30)'
+          ].join(' ');
           for (i = 1; i <= o.lines; i++) {
             seg(i, -2, filter, shadow.color);
           }

--- a/spin.js
+++ b/spin.js
@@ -317,10 +317,10 @@
           var shadow = parseShadow(o.shadow);
           var filter = [
             'progid:DXImageTransform.Microsoft.Blur(pixelradius=' + shadow.radius + ')',
-            'progid:DXImageTransform.Microsoft.Alpha(Opacity=30)'
+            'progid:DXImageTransform.Microsoft.Alpha(Opacity=' + (100 - parseInt(shadow.radius) * 10) + ')'
           ].join(' ');
           for (i = 1; i <= o.lines; i++) {
-            seg(i, -2, filter, shadow.color);
+            seg(i, 0, filter, shadow.color);
           }
         }
         for (i = 1; i <= o.lines; i++) seg(i);

--- a/spin.js
+++ b/spin.js
@@ -132,8 +132,6 @@
         radius: '4px',
         color: '#000'
       });
-      // Build the final shadow string
-      shadow.string = [shadow.left, shadow.top, shadow.radius, shadow.color].join(' ');
     }
     return shadow;
   }
@@ -231,6 +229,7 @@
       
       // Determine how to draw the shadow
       var shadow = parseShadow(o.shadow);
+      shadow.string = '0 0 ' + shadow.radius + ' ' + shadow.color;
 
       function fill(color, shadow) {
         return css(createEl(), {
@@ -252,7 +251,7 @@
           opacity: o.opacity,
           animation: useCssAnimations && addAnimation(o.opacity, o.trail, i, o.lines) + ' ' + 1/o.speed + 's linear infinite'
         });
-        if (o.shadow) ins(seg, css(fill(shadow.color, shadow.string), {top: 2+'px'}));
+        if (o.shadow) ins(seg, css(fill(shadow.color, shadow.string), {top: shadow.top, left: shadow.left}));
         ins(el, ins(seg, fill(o.color, '0 0 1px rgba(0,0,0,.1)')));
       }
       return el;


### PR DESCRIPTION
It only affects non-vml mode, but will fall back to the current default shadow in that case. Shadows can be defined with quite a bit more control, like so:

``` javascript
new Spinner({
    ...
    shadow: {
        top: '0',
        left: '0',
        radius: '4px',
        color: '#000'
    }
});

// OR

new Spinner({
    ...
    shadow: '0 0 4px #000'
});
```

The current way (`shadow: true`) still works and defaults to the current shadow.
