### PR TITLE
Updated the code so that auto will center the div in the containing div.

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -159,8 +159,8 @@
         tp = pos(target)
         ep = pos(el)
         css(el, {
-          left: (o.left == 'auto' ? tp.x-ep.x + (target.offsetWidth >> 1) : parseInt(o.left, 10) + mid) + 'px',
-          top: (o.top == 'auto' ? tp.y-ep.y + (target.offsetHeight >> 1) : parseInt(o.top, 10) + mid)  + 'px'
+          left: (o.left == 'auto' ? '50%' : parseInt(o.left, 10) + mid) + 'px',
+          top: (o.top == 'auto' ? '50%' : parseInt(o.top, 10) + mid)  + 'px'
         })
       }
 


### PR DESCRIPTION
I'm not sure what this line was doing, but it was setting the position of my element to 0,0 which was in the upper left corner.  I had nothing in my div so maybe the height wasn't work properly?  50% on each centered the spinner div in my div.
