### PR TITLE
Avoid errors with RequireJS by naming the module.

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -313,7 +313,7 @@
   })()
 
   if (typeof define == 'function' && define.amd)
-    define(function() { return Spinner })
+    define('spinner', function() { return Spinner })
   else
     window.Spinner = Spinner
 


### PR DESCRIPTION
If spin.js is loaded after RequireJS has been started and there is already an anonymous module, RequireJS raises an error.

This commit fixes it.
