### PR TITLE
Fixed changelog typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@ target.appendChild(spinner.el);
 </ul>
 <h3 id="v1.2.7">Version 1.2.7 (2.10.2012)</h3>
 <ul>
-  <li>Added an option to set the position porperty. See <a href="https://github.com/fgnass/spin.js/issues/93">issue #98</a>.</li>
+  <li>Added an option to set the position property. See <a href="https://github.com/fgnass/spin.js/issues/93">issue #98</a>.</li>
   <li>Added a trailing semicolon to support concatenation tools that don't know about ASI.</li>
 </ul>
 <h3 id="v1.2.6">Version 1.2.6 (30.08.2012)</h3>


### PR DESCRIPTION
"property" was misspelled as "porperty".
