### PR TITLE
Support for multiple line colors

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -130,6 +130,16 @@
     return o
   }
 
+  /**
+   * Returns line color from string or from array based on index.
+   */
+   function getColor(color, idx){
+    if( typeof color == 'object' && color.length ){
+      return color[ idx % color.length];
+    }
+    return color;
+   }
+
   // Built-in defaults
 
   var defaults = {
@@ -259,8 +269,7 @@
         })
 
         if (o.shadow) ins(seg, css(fill('#000', '0 0 4px ' + '#000'), {top: 2+'px'}))
-
-        ins(el, ins(seg, fill(o.color, '0 0 1px rgba(0,0,0,.1)')))
+        ins(el, ins(seg, fill(getColor(o.color, i), '0 0 1px rgba(0,0,0,.1)')))
       }
       return el
     },
@@ -314,7 +323,7 @@
                 top: -o.width>>1,
                 filter: filter
               }),
-              vml('fill', {color: o.color, opacity: o.opacity}),
+              vml('fill', {color: getColor(o.color, i), opacity: o.opacity}),
               vml('stroke', {opacity: 0}) // transparent stroke to fix color bleeding upon opacity change
             )
           )


### PR DESCRIPTION
Hello,

First of all thanks for the great spinner! I love it!
I work as an HTML5 developer at Kaltura. We use Spin.js in our player http://player.kaltura.com/docs/
Currently i'm working on the next big release of the player and we wanted to add something unique to the spinner and make it look like our logo:

![kaltura-sun](https://f.cloud.github.com/assets/1016375/982321/09081a6e-07e3-11e3-9b23-260ef9f84dc9.png)

So I've added support to pass Array of colors instead of single color.
I've maintained backward compatibility and Tested on IE, Firefox and Chrome.

You try it by passing this array as example:

``` javascript
{ 
color: [
    'rgb(132,179,82)', 
    'rgb(229,163,46)', 
    'rgb(203,55,50)', 
    'rgb(83, 151, 215)', 
    'rgb(244,206,50)' 
    ]
}
```

I would be happy if you can merge into the project. 
