### PR TITLE
Enable data attributes to set spinner configuration

### DIFF
--- a/jquery.spin.js
+++ b/jquery.spin.js
@@ -66,9 +66,22 @@ $('#el').spin('flower', 'red');
           { color: color || $this.css('color') },
           $.fn.spin.presets[opts] || opts
         )
+        
+        opts = useDataAttributes(opts, data)
+        
         data.spinner = new Spinner(opts).spin(this)
       }
     })
+  }
+  
+  function useDataAttributes(opts, data) {
+    var attrs = ['lines', 'length', 'width', 'radius', 'corners', 'rotate', 'direction', 'color', 'speed', 'trail', 'shadow', 'hwaccel', 'className', 'zIndex', 'top', 'left'];
+    for (attr in attrs) {
+      if (data[attrs[attr]]) {
+        opts[attrs[attr]] = data[attrs[attr]];
+      }
+    }
+    return opts;
   }
 
   $.fn.spin.presets = {

--- a/jquery.spin.js
+++ b/jquery.spin.js
@@ -77,7 +77,7 @@ $('#el').spin('flower', 'red');
   function useDataAttributes(opts, data) {
     var attrs = ['lines', 'length', 'width', 'radius', 'corners', 'rotate', 'direction', 'color', 'speed', 'trail', 'shadow', 'hwaccel', 'className', 'zIndex', 'top', 'left'];
     for (attr in attrs) {
-      if (data[attrs[attr]]) {
+      if (data[attrs[attr]] !== undefined) {
         opts[attrs[attr]] = data[attrs[attr]];
       }
     }


### PR DESCRIPTION
For people who might be used to use data attributes to configure elements or cases where it may be handy.

I encountered a case where I would have liked to have data attributes available so I thought I'd contribute back to anyone else who may also want that in the jQuery plugin.
