### PR TITLE
Add list of ignored files to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,5 +7,15 @@
   "repository": {
     "type": "git",
     "url": "git://github.com/fgnass/spin.js.git"
-  }
+  },
+  "ignore": [
+    "*.html",
+    "*.ico",
+    "Makefile",
+    "assets",
+    "bower.json",
+    "component.json",
+    "example",
+    "package.json"
+  ]
 }


### PR DESCRIPTION
When installing spin.js via Bower, it brings along a number of files
that are not generally useful for the consumer of the package. This can
be annoying or inconvenient when checking in Bower components. Adding
these files to the ignore list will prevent this from happening.
