### PR TITLE
Show wait cursor over the spinners lines

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -246,7 +246,8 @@
           boxShadow: shadow,
           transformOrigin: 'left',
           transform: 'rotate(' + ~~(360/o.lines*i+o.rotate) + 'deg) translate(' + o.radius+'px' +',0)',
-          borderRadius: (o.corners * o.width>>1) + 'px'
+          borderRadius: (o.corners * o.width>>1) + 'px',
+          cursor: 'wait'
         })
       }
 


### PR DESCRIPTION
When the mouse is moved over the lines of the spinner, at the moment the default cursor is shown.  Since the spinner is really telling the user that some process is running, it would follow that the mouse cursor for the UI is more than likely going to be the wait cursor, therefore, should the cursor for the lines not also be wait?

Thanks