### PR TITLE
Require spin.js instead of just spin

### DIFF
--- a/jquery.spin.js
+++ b/jquery.spin.js
@@ -37,7 +37,7 @@ $('#el').spin('flower', 'red');
 
   if (typeof exports == 'object') {
     // CommonJS
-    factory(require('jquery'), require('spin'))
+    factory(require('jquery'), require('spin.js'))
   }
   else if (typeof define == 'function' && define.amd) {
     // AMD, register as anonymous module


### PR DESCRIPTION
Requiring jquery.spin throws an error because it's trying to require('spin') rather than require('spin.js') which is the directory name in npm. I think this is just a typo as it works fine it I switch 'spin' to 'spin.js'
