### PR TITLE
Changes to auto stop spinner after fix interval

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -143,7 +143,9 @@
     className: 'spinner', // CSS class to assign to the element
     top: '50%',           // center vertically
     left: '50%',          // center horizontally
-    position: 'absolute'  // element position
+    position: 'absolute',  // element position
+    stopTimer: 7000,      // Default time for stoppining the spinner
+    autoStop: false       //Flag if spinner should be stop automatically
   }
 
   /** The constructor */
@@ -176,7 +178,12 @@
       if (target) {
         target.insertBefore(el, target.firstChild||null)
       }
-
+      if (o.autoStop){
+        setInterval(function () {
+                    if (self.el != undefined)
+                        self.stop();
+                }, o.stopTimer);
+      }
       el.setAttribute('role', 'progressbar')
       self.lines(el, self.opts)
 


### PR DESCRIPTION
Added 2 parameters:
1) Autostop?: boolean(default false) - to specify if spinner should be automatically stopped or not
2) Stoptimer?: number(default 7000) - to specify the time to stop the timer automatically after specified milliseconds (7000-> 7 sec)

On starting the spinner, if the autostop is set to true then the spinner would get stop automatically after 7 sec(default) or by given interval in Stoptimer parameter of the spinner instance.

This changes resoved my issue to stop spinner automatically if server fails to response that I have specified in Issue #268 https://github.com/fgnass/spin.js/issues/268
