### PR TITLE
Fix version number in metadata files

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "spin.js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "spin.js",
   "dependencies": {},
   "readme": "README.md",

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "spin",
   "repo": "fgnass/spin.js",
   "description": "A spinning activity indicator",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "spin.js",
   "scripts": [
     "spin.js"


### PR DESCRIPTION
The version in the metadata files does not match the published version.

The 2.0.2 tag should probably be fixed after applying this.