### PR TITLE
Update UMD Shim to be resilient to HTMLElement global pollution

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -32,7 +32,7 @@
 ;(function (root, factory) {
 
   /* CommonJS */
-  if (typeof exports == 'object') module.exports = factory()
+  if (typeof module == 'object' && module.exports) module.exports = factory()
 
   /* AMD module */
   else if (typeof define == 'function' && define.amd) define(factory)


### PR DESCRIPTION
Please see https://github.com/umdjs/umd/pull/63/files and https://github.com/umdjs/umd/issues/35 for more information, but
this change prevents an HTML element with an id of `module` from cuasing the UMD shim to incorrectly detect the enivornment as node.