### PR TITLE
truncate long decimals in animate style property name

### DIFF
--- a/spin.js
+++ b/spin.js
@@ -83,7 +83,7 @@
         '0%{opacity:' + z + '}' +
         start + '%{opacity:' + alpha + '}' +
         (start+0.01) + '%{opacity:1}' +
-        (start+trail) % 100 + '%{opacity:' + alpha + '}' +
+        ((start+trail) % 100).toFixed(2) + '%{opacity:' + alpha + '}' +
         '100%{opacity:' + z + '}' +
         '}', sheet.cssRules.length);
 


### PR DESCRIPTION
When assigning the float to a CSS animate value, IE was incorrectly assigning this property name if the calculated value contained too many characters. See issue #327 
[See IE Screenshot](http://imgur.com/C1IniPD)
