### PR TITLE
Add support for custom box-shadow values with corrected positioning

### DIFF
--- a/SpinnerOptions.d.ts
+++ b/SpinnerOptions.d.ts
@@ -35,7 +35,7 @@ export interface SpinnerOptions {
     color?: string | string[];
 
     /**
-     * Opacity of the lines (0..1)
+     * The minimum opacity the line color will fade to (0..1)
      */
     opacity?: number;
 
@@ -85,9 +85,10 @@ export interface SpinnerOptions {
     left?: string;
 
     /**
-     * Whether to render a shadow
+     * Whether to render the default shadow (boolean).
+     * A string can be used to set a custom box-shadow value.
      */
-    shadow?: boolean;
+    shadow?: boolean | string;
 
     /**
      * Element positioning

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "grunt": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-gh-pages": "^2.0.0",
-    "rollup": "^0.51.5",
+    "rollup": "^0.51.8",
     "static-server": "^2.0.6",
     "typescript": "^2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "grunt": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-gh-pages": "^2.0.0",
-    "rollup": "^0.51.8",
-    "static-server": "^2.0.6",
+    "rollup": "^0.52.0",
+    "static-server": "^3.0.0",
     "typescript": "^2.6.1"
   },
   "dependencies": {}

--- a/site/assets/main.css
+++ b/site/assets/main.css
@@ -108,7 +108,6 @@ h3 {
 #preview {
   position: relative;
   background: #333;
-  color: #fff;
   float: left;
   width: 375px;
   height: 420px;

--- a/site/index.html
+++ b/site/index.html
@@ -50,7 +50,7 @@
     <label>Color:</label><input class="string" type="text" name="color" value="#fff"><br>
     <label>↕:</label><input class="percent" type="range" name="top" min="0" max="100" value="50"><br>
     <label>↔:</label><input class="percent" type="range" name="left" min="0" max="100" value="50"><br>
-    <label>Shadow:</label><input type="checkbox" name="shadow"><br>
+    <label>Shadow:</label><input class="string" type="text" name="shadow" value="none"><br>
   </form>
 
   <div class="share">
@@ -110,7 +110,7 @@ var opts = {
   className: 'spinner', // The CSS class to assign to the spinner
   top: '<span id="opt-top" class="str">50%</span>', // Top position relative to parent
   left: '<span id="opt-left" class="str">50%</span>', // Left position relative to parent
-  shadow: <span id="opt-shadow" class="kwd">true</span>, // Whether to render a shadow
+  shadow: <span id="opt-shadow" class="str">none</span>, // Box-shadow for the lines
   position: 'absolute' // Element positioning
 };
 

--- a/site/index.html
+++ b/site/index.html
@@ -47,7 +47,7 @@
     <br>
     <label>Speed:</label><input type="range" name="speed" min="0.5" max="2.2" step="0.1" value="1"><br>
     <label>Trail:</label><input type="range" name="trail" min="10" max="100" value="60"><br>
-    <label>Color:</label><input class="string" type="text" name="color" value="#fff"><br>
+    <label>Color:</label><input class="string" type="color" name="color" value="#ffffff"><br>
     <label>↕:</label><input class="percent" type="range" name="top" min="0" max="100" value="50"><br>
     <label>↔:</label><input class="percent" type="range" name="left" min="0" max="100" value="50"><br>
     <label>Shadow:</label><input class="string" type="text" name="shadow" value="none"><br>

--- a/site/index.js
+++ b/site/index.js
@@ -13,7 +13,7 @@ if (hash) {
 
     hash[1].split(/&/).forEach(function (pair) {
         var kv = pair.split(/=/);
-        params[kv[0]] = kv[kv.length - 1];
+        params[kv[0]] = decodeURIComponent(kv[kv.length - 1]);
     });
 }
 
@@ -107,7 +107,7 @@ function getParamStringFromOpts(opts) {
                 val = val.slice(0, -1);
             }
 
-            params.push(prop + '=' + val);
+            params.push(prop + '=' + encodeURIComponent(val));
         }
     }
 

--- a/site/index.js
+++ b/site/index.js
@@ -1,6 +1,6 @@
 import { Spinner } from "../spin.js";
 
-var inputs = document.querySelectorAll('#opts input[type="range"], #opts input[type="text"], #opts select');
+var inputs = document.querySelectorAll('#opts input[type="range"], #opts input[type="color"], #opts input[type="text"], #opts select');
 var cbInputs = document.querySelectorAll('#opts input[type="checkbox"]');
 var spinnerEl = document.getElementById('preview');
 var shareEl = document.getElementById('share');

--- a/spin.ts
+++ b/spin.ts
@@ -44,7 +44,8 @@ export class Spinner {
     spin(target?: HTMLElement): this {
         this.stop();
 
-        this.el = createEl('div', { className: this.opts.className });
+        this.el = document.createElement('div');
+        this.el.className = this.opts.className;
         this.el.setAttribute('role', 'progressbar');
 
         css(this.el, {
@@ -52,7 +53,8 @@ export class Spinner {
             width: 0,
             zIndex: this.opts.zIndex,
             left: this.opts.left,
-            top: this.opts.top
+            top: this.opts.top,
+            transform: `scale(${this.opts.scale})`,
         });
 
         if (target) {
@@ -152,19 +154,6 @@ function getLineOpacity(line: number, state: number, opts: SpinnerOptions): numb
 }
 
 /**
- * Utility function to create elements. Optionally properties can be passed.
- */
-function createEl(tag: string, prop = {}): HTMLElement {
-    var el = document.createElement(tag);
-
-    for (var n in prop) {
-        el[n] = prop[n];
-    }
-
-    return el;
-}
-
-/**
  * Tries various vendor prefixes and returns the first supported property.
  */
 function vendor(el: HTMLElement, prop: string): string {
@@ -204,10 +193,6 @@ function getColor(color: string | string[], idx): string {
  * Internal method that draws the individual lines.
  */
 function drawLines(el: HTMLElement, opts: SpinnerOptions): void {
-    css(el, {
-        transform: `scale(${opts.scale})`
-    });
-
     let borderRadius = (Math.round(opts.corners * opts.width * 500) / 1000) + 'px';
     let shadow = 'none';
 
@@ -222,7 +207,7 @@ function drawLines(el: HTMLElement, opts: SpinnerOptions): void {
     for (let i = 0; i < opts.lines; i++) {
         let degrees = ~~(360 / opts.lines * i + opts.rotate);
 
-        let backgroundLine = css(createEl('div'), {
+        let backgroundLine = css(document.createElement('div'), {
             position: 'absolute',
             top: `${-opts.width / 2}px`,
             width: (opts.length + opts.width) + 'px',
@@ -232,7 +217,7 @@ function drawLines(el: HTMLElement, opts: SpinnerOptions): void {
             transform: `rotate(${degrees}deg) translateX(${opts.radius}px)`,
         });
 
-        let line = css(createEl('div'), {
+        let line = css(document.createElement('div'), {
             width: '100%',
             height: '100%',
             background: getColor(opts.color, i),


### PR DESCRIPTION
Directly applying a box-shadow to the spinner lines would cause the shadow to be rotated along with the lines, which doesn't look natural. Previously, this was avoided by generating another element for each line, coloring it black and applying a black box-shadow, and then positioning it down a couple pixels beneath the line. However, this approach didn't allow customization of the shadow position and color, and also blocked use of inset shadows or multiple blended shadows with different positions.

This commit solves these issues by parsing a standard box-shadow value to determine its x and y offsets, and then using trigonometry to correct the shadow coordinates for each line based on its degrees of rotation.

Resolves #35.